### PR TITLE
refactor: 修改Layout样式与其他页面样式 (#3)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <NuxtRouteAnnouncer />
+    <NuxtRouteAnnouncer/>
     <NuxtLayout>
       <NuxtPage/>
     </NuxtLayout>

--- a/composables/useCoffeeData.ts
+++ b/composables/useCoffeeData.ts
@@ -1,21 +1,23 @@
 export interface CoffeeData {
-    id:number;
+    id: number;
     name: string
     brand: string
     minCaffeine: number
     maxCaffeine: number
 }
+
 export interface TableTitle {
-    id:number;
+    id: number;
     nameTitle: string
     brandTitle: string
     minCaffeineTitle: string
     maxCaffeineTitle: string
 }
-export const useCoffeeData=()=>{
-    return useState<CoffeeData[]>('coffeeData',()=>[
-        {id:0,brand:'AIRBAG COFFEE',name:'美式咖啡',minCaffeine:388,maxCaffeine:388,},
-        {id:1,brand:'AIRBAG COFFEE', name: '香草拿铁', minCaffeine: 116.1, maxCaffeine: 116.1}
+
+export const useCoffeeData = () => {
+    return useState<CoffeeData[]>('coffeeData', () => [
+        {id: 0, brand: 'AIRBAG COFFEE', name: '美式咖啡', minCaffeine: 388, maxCaffeine: 388,},
+        {id: 1, brand: 'AIRBAG COFFEE', name: '香草拿铁', minCaffeine: 116.1, maxCaffeine: 116.1},
         {id: 2, brand: 'AIRBAG COFFEE', name: '拿铁', minCaffeine: 117.94, maxCaffeine: 117.94},
         {id: 3, brand: 'COSTA 咖啡', name: '香草拿铁', minCaffeine: 103.66, maxCaffeine: 103.66},
         {id: 4, brand: 'COSTA 咖啡', name: '拿铁', minCaffeine: 107.58, maxCaffeine: 107.58},

--- a/composables/useRouteParams.ts
+++ b/composables/useRouteParams.ts
@@ -1,18 +1,20 @@
-export interface RouterItem{
+export interface RouterItem {
     name: string;
     path: string;
+    icon?: string;
 }
-export const useRouteDefine=()=>{
-    return useState<RouterItem[]>('routeDefine',()=>[
+
+export const useRouteDefine = () => {
+    return useState<RouterItem[]>('routeDefine', () => [
         {name: '首页', path: '/', icon: "HomeFilled"},
         {name: '计数器', path: '/counter', icon: "Odometer"},
         {name: '收藏列表', path: '/collections', icon: "Star"},
         {name: '咖啡管理', path: '/coffee', icon: "HotWater"},
     ])
 }
-export const useNowRouteTitle=()=>{
-    return useState<string>('nowRouteTitle',()=>'')
+export const useNowRouteTitle = () => {
+    return useState<string>('nowRouteTitle', () => '')
 }
-export const useNowRouteIcon=()=>{
-    return useState<string>('nowRouteIcon',()=>'')
+export const useNowRouteIcon = () => {
+    return useState<string>('nowRouteIcon', () => '')
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,33 +10,32 @@ const route = useRoute()
 
 <template>
   <el-container class="h-screen w-screen">
-    <el-aside class="border-r">
-      <el-container class="items-center">
-        <el-header class="text-center mt-5 font-bold text-2xl ">{{ menuTitle }}</el-header>
-
-        <el-menu class="border-none w-full" :router="true" :default-active="route.path">
-          <!--suppress HtmlUnknownTarget -->
-          <el-menu-item class="border rounded-lg justify-center m-5" v-for="item in routePathList" :key="item.name"
-                        :index="item.path">
-           <span v-if="routeIcon !==undefined&&routeIcon !==''">
-             <el-icon><component :is="item.icon"></component></el-icon>
+    <el-aside class="border-r bg-white">
+      <div class="text-center mt-5 font-bold text-2xl">{{ menuTitle }}</div>
+      <el-menu class="border-none w-full" :router="true" :default-active="route.path">
+        <el-menu-item class="border rounded-lg justify-center m-5" v-for="item in routePathList" :key="item.name"
+                      :index="item.path">
+           <span v-if="routeIcon !== undefined && routeIcon !== ''">
+             <el-icon>
+               <component :is="item.icon"></component>
+             </el-icon>
            </span>
-            {{ item.name }}
-          </el-menu-item>
-        </el-menu>
-
-      </el-container>
+          {{ item.name }}
+        </el-menu-item>
+      </el-menu>
     </el-aside>
     <el-container>
-      <el-header class="mt-5 border-b font-bold text-4.5">
-        <span v-if="routeIcon !==undefined&&routeIcon !==''">
-          <el-icon>
-            <component :is="routeIcon"></component>
-          </el-icon>
-        </span>
-        {{ routeTitle }}
+      <el-header class="border-b font-bold text-4.5 bg-white">
+        <div class="flex items-center h-full">
+          <div v-if="routeIcon !==undefined&&routeIcon !==''">
+            <el-icon class="pt-4 mr-2">
+              <component :is="routeIcon"></component>
+            </el-icon>
+          </div>
+          <div>{{ routeTitle }}</div>
+        </div>
       </el-header>
-      <el-main>
+      <el-main class="p-0">
         <NuxtPage/>
       </el-main>
     </el-container>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import {useRouteDefine, useNowRouteTitle,useNowRouteIcon} from "~/composables/useRouteParams";
+import {useRouteDefine, useNowRouteTitle, useNowRouteIcon} from "~/composables/useRouteParams";
 
 const routePathList = useRouteDefine()
 const routeTitle = useNowRouteTitle()
 const menuTitle = ref("NUXT练习项目")
-const routeIcon=useNowRouteIcon()
-const route=useRoute()
+const routeIcon = useNowRouteIcon()
+const route = useRoute()
 </script>
 
 <template>
@@ -16,11 +16,12 @@ const route=useRoute()
 
         <el-menu class="border-none w-full" :router="true" :default-active="route.path">
           <!--suppress HtmlUnknownTarget -->
-          <el-menu-item class="border rounded-lg justify-center m-5" v-for="item in routePathList" :key="item.name" :index="item.path">
-           <span v-if="routeIcon !==undefined&&routeIcon !==''" >
+          <el-menu-item class="border rounded-lg justify-center m-5" v-for="item in routePathList" :key="item.name"
+                        :index="item.path">
+           <span v-if="routeIcon !==undefined&&routeIcon !==''">
              <el-icon><component :is="item.icon"></component></el-icon>
            </span>
-            {{item.name}}
+            {{ item.name }}
           </el-menu-item>
         </el-menu>
 
@@ -28,7 +29,7 @@ const route=useRoute()
     </el-aside>
     <el-container>
       <el-header class="mt-5 border-b font-bold text-4.5">
-        <span v-if="routeIcon !==undefined&&routeIcon !==''" >
+        <span v-if="routeIcon !==undefined&&routeIcon !==''">
           <el-icon>
             <component :is="routeIcon"></component>
           </el-icon>

--- a/pages/coffee.vue
+++ b/pages/coffee.vue
@@ -11,7 +11,7 @@ const handleClose = (done: () => void) => {
 </script>
 
 <template>
-  <el-container class="justify-center items-center w-screen h-screen">
+  <div>
     <el-image src="images/126854741_p0.png" class="w-full h-full fixed -z-10" fit="cover"></el-image>
     <el-dialog v-model="dialogVisible"
                title="Tips"
@@ -19,8 +19,7 @@ const handleClose = (done: () => void) => {
                :before-close="handleClose" class="fixed bg-black">
       1212
     </el-dialog>
-
-  </el-container>
+  </div>
 </template>
 
 <style scoped>

--- a/pages/coffee.vue
+++ b/pages/coffee.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const dialogVisible=ref(false);
+const dialogVisible = ref(false);
 const handleClose = (done: () => void) => {
   ElMessageBox.confirm('Are you sure to close this dialog?')
       .then(() => {
@@ -11,16 +11,16 @@ const handleClose = (done: () => void) => {
 </script>
 
 <template>
-<el-container class="justify-center items-center w-screen h-screen">
-  <el-image src="images/126854741_p0.png" class="w-full h-full fixed -z-10" fit="cover"></el-image>
-<el-dialog v-model="dialogVisible"
-  title="Tips"
-  width="500"
-  :before-close="handleClose" class="fixed bg-black" >
-1212
-</el-dialog>
+  <el-container class="justify-center items-center w-screen h-screen">
+    <el-image src="images/126854741_p0.png" class="w-full h-full fixed -z-10" fit="cover"></el-image>
+    <el-dialog v-model="dialogVisible"
+               title="Tips"
+               width="500"
+               :before-close="handleClose" class="fixed bg-black">
+      1212
+    </el-dialog>
 
-</el-container>
+  </el-container>
 </template>
 
 <style scoped>

--- a/pages/collections.vue
+++ b/pages/collections.vue
@@ -31,24 +31,20 @@ const handleTagsClick = (text: string) => {
 </script>
 
 <template>
-
-  <div class="flex w-screen h-screen justify-center items-center">
-    <el-image class="w-full h-full -z-10 fixed object-cover" src="/images/39930673_p0.jpg" alt="bg"></el-image>
-    <div class="bg-white bg-op-50 rounded-xl w-70% h-70% shadow-xl shadow-gray-6 shadow-op-20 fixed">
-      <div class="text-center font-bold text-2xl mb-4">Popular collections</div>
-      <div class="flex">
-        <div class="p-4">
-          <div @click="handleTagsClick(item)" v-for="item in tags" :key="item"
-               class="bg-op-80 inline-block px-3 py-1 rounded-full bg-gray-200 hover:bg-gray-300 cursor-pointer transition-colors duration-200 mr-2">
-            {{ item }}
-          </div>
-          <div class="flex flex-wrap overflow-y-auto max-h-400px justify-center">
-            <CollectionsCard v-for="item in collections" :key="item.id" :id="item.id" :name="item.name"
-                             :likes="item.likes" :imgSrc="itemImgPathPrefix+item.imgSrc">
-
-            </CollectionsCard>
-          </div>
+  <div class="flex h-full justify-center items-center">
+    <el-image class="w-full h-full -z-10 fixed" src="/images/39930673_p0.jpg" fit="cover"></el-image>
+    <div class="bg-white bg-op-50 rounded-xl w-70% h-70% shadow-xl shadow-gray-6 shadow-op-20 fixed p-4">
+      <div class="text-center font-bold text-2xl pb-2">Popular collections</div>
+      <div class="flex pb-2">
+        <div @click="handleTagsClick(item)" v-for="item in tags" :key="item"
+             class="bg-op-80 inline-block px-3 py-1 rounded-full bg-gray-200 hover:bg-gray-300 cursor-pointer transition-colors duration-200 mr-2">
+          {{ item }}
         </div>
+      </div>
+      <div class="flex flex-wrap overflow-y-auto max-h-82% justify-center">
+        <CollectionsCard v-for="item in collections" :key="item.id" :id="item.id" :name="item.name"
+                         :likes="item.likes" :imgSrc="itemImgPathPrefix + item.imgSrc">
+        </CollectionsCard>
       </div>
     </div>
   </div>

--- a/pages/counter.vue
+++ b/pages/counter.vue
@@ -6,8 +6,7 @@ const increment = () => num.value++
 <template>
 
   <div class="flex w-full h-full items-center justify-center">
-    <el-image class="w-full h-full object-cover -z-10" src="/images/7f3904c34dfe5414896b74934a7d5b2c.jpg"
-              alt="counter"></el-image>
+    <el-image class="w-full h-full -z-10" src="/images/7f3904c34dfe5414896b74934a7d5b2c.jpg" fit="cover"></el-image>
     <div class="p-8 bg-gray-1 bg-op-70 rounded-lg w-400px h-300px fixed flex flex-col items-center">
       <div class="font-bold text-2xl mt-4">Counter</div>
       <div class="font-bold text-1xl mt-4">Count:{{ num }}</div>
@@ -16,8 +15,6 @@ const increment = () => num.value++
           @click="increment">+1
       </button>
     </div>
-
-
   </div>
 </template>
 

--- a/pages/counter.vue
+++ b/pages/counter.vue
@@ -6,11 +6,15 @@ const increment = () => num.value++
 <template>
 
   <div class="flex w-full h-full items-center justify-center">
-    <el-image class="w-full h-full object-cover -z-10" src="/images/7f3904c34dfe5414896b74934a7d5b2c.jpg" alt="counter"></el-image>
+    <el-image class="w-full h-full object-cover -z-10" src="/images/7f3904c34dfe5414896b74934a7d5b2c.jpg"
+              alt="counter"></el-image>
     <div class="p-8 bg-gray-1 bg-op-70 rounded-lg w-400px h-300px fixed flex flex-col items-center">
       <div class="font-bold text-2xl mt-4">Counter</div>
-      <div class="font-bold text-1xl mt-4">Count:{{num}}</div>
-      <button class="hover:text-red w-full mt-4 hover:bg-op-70 bg-gray-2 hover:bg-gray-3 rounded-lg transition-colors border shadow-md shadow-gray-1 p-1" @click="increment">+1</button>
+      <div class="font-bold text-1xl mt-4">Count:{{ num }}</div>
+      <button
+          class="hover:text-red w-full mt-4 hover:bg-op-70 bg-gray-2 hover:bg-gray-3 rounded-lg transition-colors border shadow-md shadow-gray-1 p-1"
+          @click="increment">+1
+      </button>
     </div>
 
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-<div>我是NMD首页！</div>
+  <div>我是NMD首页！</div>
 </template>
 
 <style scoped>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-  <div>我是NMD首页！</div>
+  <div class="p-5">我是NMD首页！</div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
- 修改了所有包含背景图页面的背景填充样式，使用el-image想修改`object-fit`的样式应该直接用组件给的`fit`属性，而不是自己单开一个`class`或者`style`去改，组件本来给你这个修改方式了你不用，文档没仔细看。
- 修改了header的标题与图标对齐方式，能用`flex`对齐就用flex对齐，你老是喜欢用`margin`或者`padding`自己顶，费时费力还不好居中。
- 修改了main的内边距，这玩意自带`padding`会让背景图铺不满整个容器，拿F12一看就知道有内边距了，直接覆盖掉。
- 修改了一些运算符附近字符的排版，别全部挤一起写很难一眼看懂，要养成动不动就format一下代码格式的习惯，IDE的功能都是很有用的。
- 修改了`RouterItem`的定义，`?`代表这个属性可能为空，你在数据里面新加了一个`icon`属性为什么不把对应的属性也加到`interface`的定义上？IDE都报错了你也不改，如果不是因为TypeScript在运行时不会报错，你才可以运行，你这种写法放C#都要死一百次，编译都过不去，开都开不起来，泛型就是为了约束住某个对象的类型，避免出错，且能够在前期就被IDE所检测到。
- 修改了Aside、Header的背景颜色，不加上背景色main里的fixed图片会溢出显示到其他区域，能够看到的原因是因为Aside和Header没加背景颜色=透明背景=透射出底部的fixed图片。
- 删除了无用的el-container组件，能直接用div写的就用div写，不用搞那么多组件。
- 删除了无用的`<!--suppress HtmlUnknownTarget -->`注释，注释本身也算是一个元素，这里注释的作用是为了让IDE忽略掉元素里不确定的属性target，你这没有这个问题就没必要留这个注释。
- 修改了乱用`w-screen`和`h-screen`的地方，这里本来main就不是铺满整个浏览器的，无脑使用这两个属性只是乱加宽高，要用百分比去让他自适应父容器的大小，基本上除了最外围可能会用到这两个属性，或者你有个元素需要全屏显示，要不然一般不用这两个。
- 修改了收藏列表底下展示卡片的高度，这玩意不要限死高度啊，按百分比让他自适应。